### PR TITLE
change tasks association to manual_subject_of app type

### DIFF
--- a/src/containers/profile/tasks/utils/AddNewFollowUpUtils.js
+++ b/src/containers/profile/tasks/utils/AddNewFollowUpUtils.js
@@ -15,12 +15,12 @@ const {
   ASSIGNED_TO,
   FOLLOW_UPS,
   FULFILLS,
+  MANUAL_SUBJECT_OF,
   MEETINGS,
   PEOPLE,
   PROVIDER,
   REENTRY_STAFF,
   REPORTED,
-  SUBJECT_OF,
 } = APP_TYPE_FQNS;
 const {
   CATEGORY,
@@ -143,7 +143,7 @@ const getNewFollowUpAssociations = (formData :Object, personEKID :UUID) :Array<A
   const associations :Array<Array<*>> = [];
 
   // participant:
-  associations.push([SUBJECT_OF, personEKID, PEOPLE, 0, FOLLOW_UPS, {
+  associations.push([MANUAL_SUBJECT_OF, personEKID, PEOPLE, 0, FOLLOW_UPS, {
     [DATETIME_COMPLETED.toString()]: [nowISO]
   }]);
 
@@ -162,7 +162,7 @@ const getNewFollowUpAssociations = (formData :Object, personEKID :UUID) :Array<A
   // meetings:
   const category :any = getIn(formData, [pageSection, getEntityAddressKey(0, FOLLOW_UPS, CATEGORY)]);
   if (category === FOLLOW_UPS_CATEGORIES.MEETING) {
-    associations.push([SUBJECT_OF, personEKID, PEOPLE, 0, MEETINGS, {
+    associations.push([MANUAL_SUBJECT_OF, personEKID, PEOPLE, 0, MEETINGS, {
       [DATETIME_COMPLETED.toString()]: [nowISO]
     }]);
     associations.push([ASSIGNED_TO, assigneeEKID, REENTRY_STAFF, 0, MEETINGS, {

--- a/src/containers/tasks/utils/TaskManagerUtils.js
+++ b/src/containers/tasks/utils/TaskManagerUtils.js
@@ -14,9 +14,9 @@ import { FOLLOW_UPS_STATUSES } from '../../profile/tasks/FollowUpsConstants';
 const { getEntityAddressKey, getPageSectionKey } = DataProcessingUtils;
 const {
   ASSIGNED_TO,
+  MANUAL_SUBJECT_OF,
   PEOPLE,
   REPORTED,
-  SUBJECT_OF,
 } = APP_TYPE_FQNS;
 const {
   CATEGORY,
@@ -96,7 +96,7 @@ const formatTasksForTable = (
       [OL_TITLE]: title,
       [STATUS]: status
     } = getEntityProperties(task, [CATEGORY, DATETIME_COMPLETED, DESCRIPTION, GENERAL_DATETIME, OL_TITLE, STATUS]);
-    const person :Map = followUpNeighbors.getIn([taskEKID, SUBJECT_OF], Map());
+    const person :Map = followUpNeighbors.getIn([taskEKID, MANUAL_SUBJECT_OF], Map());
     const personName :string = getPersonFullName(person);
     const taskName :string = getTaskNameForTaskManager(category, title, personName);
     const dueDateString :string = `Due by: ${DateTime.fromISO(dueDateTime).toLocaleString(DateTime.DATE_SHORT)}`;


### PR DESCRIPTION
trying to separate `ol.subjectof` entity sets between integrated and non-integrated data. this is to fix which entity set is being used for the `person -> subject of -> follow-up` and `person -> subject of -> meeting`.