### PR TITLE
case notes style bug

### DIFF
--- a/src/components/casenotes/CaseNotesTableRow.js
+++ b/src/components/casenotes/CaseNotesTableRow.js
@@ -9,7 +9,7 @@ import { StyledTableRow } from '../tasks/FollowUpsTableStyles';
 const Date = styled.td`
   font-size: 14px;
   margin-right: 10px;
-  padding: 20px 15px 30px 0;
+  padding: 20px 0 20px 30px;
 `;
 
 const Staff = styled.td`


### PR DESCRIPTION
i must've messed up the padding when i was updating the styles on the profile's notes stream:

from this:
![Screen Shot 2020-08-31 at 9 46 38 AM](https://user-images.githubusercontent.com/32921059/91745049-3ae1df80-eb6f-11ea-9474-b9a93663e733.png)
to this:
![Screen Shot 2020-08-31 at 9 47 55 AM](https://user-images.githubusercontent.com/32921059/91745045-39b0b280-eb6f-11ea-8e68-e51cf26a118c.png)
