### PR TITLE
bugfix/APPS-2569 — intake submission error

### DIFF
--- a/src/containers/intake/utils/IntakeUtils.js
+++ b/src/containers/intake/utils/IntakeUtils.js
@@ -52,6 +52,7 @@ import {
   PREFERRED_METHOD_EAK,
   PREFERRED_TIME_EAK,
   RACE_EAK,
+  REFERRAL_EAK,
   REGISTRATION_EAK,
   RELEASE_PSK,
   SEX_OFFENDER_COUNTY_EAK,
@@ -616,7 +617,7 @@ const getClientReleaseAssociations = (formData :Object) => {
   const innerPageSectionKey :string = SUPERVISION_INNER_PSK;
 
   const incarcerationFacilityEKID :any = getIn(formData, [outerPageSectionKey, JAILS_PRISONS_EAK]);
-  const referredFrom :any = getIn(formData, [outerPageSectionKey, JAILS_PRISONS_EAK]);
+  const referredFrom :any = getIn(formData, [outerPageSectionKey, REFERRAL_EAK]);
 
   associations.push([MANUAL_SUBJECT_OF, 0, PEOPLE, 0, MANUAL_JAIL_STAYS, {}]);
 


### PR DESCRIPTION
Fixes a bug where the wrong property was being read from the form data to determine whether or not to include a particular association: the "incarceration facility" was the value that determined whether a `person -> subject of -> referral request` association should be made, instead of the "referral source".