### PR TITLE
Task/APPS-2570 – staff members for assigning tasks

### DIFF
--- a/src/utils/PeopleUtils.js
+++ b/src/utils/PeopleUtils.js
@@ -2,15 +2,17 @@
 import { Map } from 'immutable';
 import { DateTime } from 'luxon';
 
-import { isDefined } from './LangUtils';
 import { getEntityProperties } from './DataUtils';
+import { isDefined } from './LangUtils';
+
 import { PROPERTY_TYPE_FQNS } from '../core/edm/constants/FullyQualifiedNames';
 
 const { DOB, FIRST_NAME, LAST_NAME } = PROPERTY_TYPE_FQNS;
 
 const getPersonFullName = (personEntity :Map) :string => {
   const { [FIRST_NAME]: firstName, [LAST_NAME]: lastName } = getEntityProperties(personEntity, [FIRST_NAME, LAST_NAME]);
-  if (!isDefined(firstName) || !isDefined(lastName)) return '';
+  if (!isDefined(firstName) && isDefined(lastName)) return lastName;
+  if (isDefined(firstName) && !isDefined(lastName)) return firstName;
   const fullName = `${firstName} ${lastName}`;
   return fullName;
 };


### PR DESCRIPTION
- fixed the check for existing staff entities against user objects (with READ role)
- added more fallbacks for what name gets saved on the staff entity, based on what i've seen among reentry user objects
- updated the getPersonName util to return whatever name exists on a person entity
- tested this more thoroughly with multiple of my own emails/logins